### PR TITLE
dsnd-542 - Added x-request-id logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<skip.integration.tests>false</skip.integration.tests>
 		<skip.unit.tests>false</skip.unit.tests>
-		<private-api-sdk-java.version>2.0.124</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.130</private-api-sdk-java.version>
 		<io-cucumber.version>7.2.3</io-cucumber.version>
 
 		<!--sonar configuration-->

--- a/src/main/java/uk/gov/companieshouse/charges/data/controller/ChargesController.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/controller/ChargesController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.charges.InternalChargeApi;
 import uk.gov.companieshouse.charges.data.service.ChargesService;
@@ -33,6 +34,7 @@ public class ChargesController {
      */
     @PutMapping("/company/{company_number}/charge/{charge_id}/internal")
     public ResponseEntity<Void> saveOrUpdateCharges(
+            @RequestHeader("x-request-id") final String contextId,
             @PathVariable("company_number") final String companyNumber,
             @PathVariable("charge_id") final String chargeId,
             @RequestBody final InternalChargeApi requestBody
@@ -41,7 +43,7 @@ public class ChargesController {
                 "Started : Save or Update charge %s with company number %s ",
                 chargeId,
                 companyNumber));
-        this.chargesService.upsertCharges(companyNumber, chargeId, requestBody);
+        this.chargesService.upsertCharges(contextId, companyNumber, chargeId, requestBody);
         logger.debug(String.format(
                 "Finished : Save or Update charge %s with company number %s ",
                 chargeId,

--- a/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
@@ -40,7 +40,7 @@ public class ChargesService {
      * @param requestBody   request body.
      */
     @Transactional
-    public void upsertCharges(String companyNumber, String chargeId,
+    public void upsertCharges(String contextId, String companyNumber, String chargeId,
             InternalChargeApi requestBody) {
         logger.debug(String.format("Started : Save or Update charge %s with company number %s ",
                 chargeId,
@@ -54,7 +54,7 @@ public class ChargesService {
                 chargeId,
                 companyNumber));
 
-        chargesApiService.invokeChsKafkaApi(companyNumber);
+        chargesApiService.invokeChsKafkaApi(contextId, companyNumber);
 
         logger.info(String.format("DSND-542: ChsKafka api invoked successfully for company number"
                 + " %s", companyNumber));

--- a/src/test/java/uk/gov/companieshouse/charges/data/api/ChargesApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/data/api/ChargesApiClientServiceTest.java
@@ -46,7 +46,7 @@ public class ChargesApiClientServiceTest {
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(changedResourcePost);
         when(changedResourcePost.execute()).thenReturn(response);
 
-        ApiResponse<?> apiResponse = chargesApiService.invokeChsKafkaApi("CH4000056");
+        ApiResponse<?> apiResponse = chargesApiService.invokeChsKafkaApi("1234", "CH4000056");
 
         Assertions.assertThat(apiResponse).isNotNull();
 
@@ -65,7 +65,7 @@ public class ChargesApiClientServiceTest {
         when(changedResourcePost.execute()).thenThrow(RuntimeException.class);
 
 
-        Assert.assertThrows(RuntimeException.class, () -> chargesApiService.invokeChsKafkaApi("CH4000056"));
+        Assert.assertThrows(RuntimeException.class, () -> chargesApiService.invokeChsKafkaApi("1234", "CH4000056"));
 
         verify(apiClientService, times(1)).getInternalApiClient();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();

--- a/src/test/java/uk/gov/companieshouse/charges/data/controller/ChargesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/data/controller/ChargesControllerTest.java
@@ -64,6 +64,7 @@ public class ChargesControllerTest {
         doNothing().when(chargesService).upsertCharges(eq("02588581"), eq("02588581"), eq("02588581"), isA(InternalChargeApi.class));
         String url = String.format("/company/%s/charge/%s/internal", "02588581", "02588581");
         mockMvc.perform(put(url).contentType(APPLICATION_JSON)
+                .header("x-request-id", "02588581")
                 .content(gson.toJson(request))).andExpect(status().isOk());
     }
 

--- a/src/test/java/uk/gov/companieshouse/charges/data/controller/ChargesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/data/controller/ChargesControllerTest.java
@@ -61,7 +61,7 @@ public class ChargesControllerTest {
     public void callChargesPutRequest() throws Exception {
 
         InternalChargeApi request = new InternalChargeApi();
-        doNothing().when(chargesService).upsertCharges(eq("02588581"), eq("02588581"), isA(InternalChargeApi.class));
+        doNothing().when(chargesService).upsertCharges(eq("02588581"), eq("02588581"), eq("02588581"), isA(InternalChargeApi.class));
         String url = String.format("/company/%s/charge/%s/internal", "02588581", "02588581");
         mockMvc.perform(put(url).contentType(APPLICATION_JSON)
                 .content(gson.toJson(request))).andExpect(status().isOk());


### PR DESCRIPTION
dsnd-542 - Added x-request-id logic and related context id in the body when calling chs-kafka-api