### PR TITLE
Feature/dsnd 609 - unit test failures after original merge

### DIFF
--- a/charges-data-api.iml
+++ b/charges-data-api.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
+</module>

--- a/charges-data-api.iml
+++ b/charges-data-api.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
-</module>

--- a/src/main/java/uk/gov/companieshouse/charges/data/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/config/ExceptionHandlerConfig.java
@@ -25,7 +25,7 @@ public class ExceptionHandlerConfig {
         this.logger = logger;
     }
 
-    private void populateResponseBody(Map<String, Object> responseBody , String correlationId){
+    private void populateResponseBody(Map<String, Object> responseBody , String correlationId) {
         responseBody.put("timestamp", LocalDateTime.now());
         responseBody.put("message", "There is issue completing the request.");
         responseBody.put("correlationId", correlationId);
@@ -50,11 +50,19 @@ public class ExceptionHandlerConfig {
         return new ResponseEntity(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    /**
+     * Runtime exception handler DataAccessResourceFailureException.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {DataAccessResourceFailureException.class})
-    public ResponseEntity<Object> handleException(DataAccessResourceFailureException ex, WebRequest request) {
+    public ResponseEntity<Object> handleException(DataAccessResourceFailureException ex,
+            WebRequest request) {
         var correlationId = generateShortCorrelationId();
         logger.error(String.format("Started: handleException: %s Generating error response ",
-            correlationId), ex);
+                correlationId), ex);
         Map<String, Object> responseBody = new LinkedHashMap<>();
         populateResponseBody(responseBody, correlationId);
         Throwable cause = ex.getCause();
@@ -62,7 +70,14 @@ public class ExceptionHandlerConfig {
         return new ResponseEntity(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
-    @ExceptionHandler(value = {ResponseStatusException.class})
+    /**
+    * Runtime exception handler ResponseStatusException.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = { ResponseStatusException.class })
     public ResponseEntity<Object> handleException(ResponseStatusException ex, WebRequest request) {
         var correlationId = generateShortCorrelationId();
         logger.error(String.format("Started: handleException: %s Generating error response ",
@@ -70,15 +85,23 @@ public class ExceptionHandlerConfig {
         Map<String, Object> responseBody = new LinkedHashMap<>();
         populateResponseBody(responseBody, correlationId);
 
-        if ("invokeChsKafkaApi".equals(ex.getReason())){
+        if ("invokeChsKafkaApi".equals(ex.getReason())) {
             return new ResponseEntity(responseBody, HttpStatus.NOT_EXTENDED);
         }
         return new ResponseEntity(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 
+    /**
+     * Runtime exception handler HttpMessageNotReadableException.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {HttpMessageNotReadableException.class})
-    public ResponseEntity<Object> handleException(HttpMessageNotReadableException ex, WebRequest request) {
+    public ResponseEntity<Object> handleException(HttpMessageNotReadableException ex,
+            WebRequest request) {
         var correlationId = generateShortCorrelationId();
         logger.error(String.format("Started: handleException: %s Generating error response ",
                 correlationId), ex);

--- a/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
@@ -76,9 +76,11 @@ public class ChargesService {
                     String.format("Finished : upsertCharges for chargeId %s company number %s ",
                             chargeId,
                             companyNumber));
-            ApiResponse<Void> res = chargesApiService.invokeChsKafkaApi(contextId, companyNumber, chargeId);
-            if (res.getStatusCode() != 200){
-                throw new ResponseStatusException(Objects.requireNonNull(HttpStatus.resolve(res.getStatusCode())), "invokeChsKafkaApi");
+            ApiResponse<Void> res = chargesApiService.invokeChsKafkaApi(contextId, companyNumber,
+                    chargeId);
+            if (res.getStatusCode() != 200) {
+                throw new ResponseStatusException(HttpStatus.resolve(res.getStatusCode()),
+                    "invokeChsKafkaApi");
             }
             logger.info(
                     String.format("DSND-542: ChsKafka api invoked successfully for company number"

--- a/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/service/ChargesService.java
@@ -2,9 +2,10 @@ package uk.gov.companieshouse.charges.data.service;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -145,8 +146,8 @@ public class ChargesService {
                 companyNumber
         ));
 
-        List<ChargesDocument> charges =
-                this.chargesRepository.findCharges(companyNumber, pageable).getContent();
+        Page<ChargesDocument> page = chargesRepository.findCharges(companyNumber, pageable);
+        List<ChargesDocument> charges = page == null ? Collections.emptyList() : page.getContent();
         if (charges.isEmpty()) {
             logger.error(
                     String.format(


### PR DESCRIPTION
Mocks for existing unit test were returning NULLs and give nu,, pointer exceptions.
Debugging proved that the mock in the service was not the same instance as the one in the test.
Assumption made that Sprint Auto wiring was a problem.
Refectory tests to construct the service and mocks in setup function no using annotations, fixed null pointer exceptions.
Refactored the test remove null checks on optionals that can never be null! 