### PR TITLE
DSND-1086 Removing transaction_id field from InsolvencyCaseApi and other

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 		<skip.integration.tests>false</skip.integration.tests>
 		<skip.unit.tests>false</skip.unit.tests>
-		<private-api-sdk-java.version>2.0.177</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.180</private-api-sdk-java.version>
 		<io-cucumber.version>7.2.3</io-cucumber.version>
 		<wiremock.standalone.version>2.32.0</wiremock.standalone.version>
 		<maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>

--- a/src/itest/resources/payload/input/Insolvency_cases_Invalid_input.json
+++ b/src/itest/resources/payload/input/Insolvency_cases_Invalid_input.json
@@ -21,7 +21,7 @@
     "charge_code": null,
     "insolvency_cases": [
       { 
-      "case_number" : "1",  
+      "case_number" : 1,
       "links" : { 
         "case" : "/company/04796390/insolvency#case-1"  
       },  

--- a/src/itest/resources/payload/input/charge-api-request-data-1.json
+++ b/src/itest/resources/payload/input/charge-api-request-data-1.json
@@ -26,8 +26,7 @@
     "charge_code": "NI6224000001",
     "insolvency_cases": [
       {
-        "case_number": 2,
-        "transaction_id": 22222,
+        "case_number": "2",
         "links": null
       }
     ],

--- a/src/itest/resources/payload/input/charge-api-request-data-2.json
+++ b/src/itest/resources/payload/input/charge-api-request-data-2.json
@@ -26,8 +26,7 @@
     "charge_code": "NI6224000001",
     "insolvency_cases": [
       {
-        "case_number": 2,
-        "transaction_id": 22222,
+        "case_number": "2",
         "links": null
       }
     ],

--- a/src/itest/resources/payload/input/obligation_secured_&_nature_of_charge_Happy_Path_input.json
+++ b/src/itest/resources/payload/input/obligation_secured_&_nature_of_charge_Happy_Path_input.json
@@ -24,7 +24,6 @@
     "insolvency_cases": [
       {
         "case_number": null,
-        "transaction_id": null,
         "links": null
       }
     ],

--- a/src/itest/resources/payload/input/satisfied_on_Happy_Path_input.json
+++ b/src/itest/resources/payload/input/satisfied_on_Happy_Path_input.json
@@ -24,7 +24,6 @@
     "insolvency_cases": [
       {
         "case_number": null,
-        "transaction_id": null,
         "links": null
       }
     ],

--- a/src/itest/resources/payload/output/Insolvency_cases_Happy_Path_output.json
+++ b/src/itest/resources/payload/output/Insolvency_cases_Happy_Path_output.json
@@ -81,8 +81,7 @@
         ],
         "insolvency_cases" : [
             {
-                "case_number" : 1,
-                "transaction_id" : 3129317274,
+                "case_number" : "1",
                 "links" : {
                     "case" : "/company/04796390/insolvency#case-1"
                 }

--- a/src/itest/resources/payload/output/obligation_secured_&_nature_of_charge_Happy_Path_output.json
+++ b/src/itest/resources/payload/output/obligation_secured_&_nature_of_charge_Happy_Path_output.json
@@ -52,7 +52,6 @@
         "insolvency_cases" : [ 
             {
                 "case_number" : null,
-                "transaction_id" : null,
                 "links" : null
             }
         ],

--- a/src/itest/resources/payload/output/satisfied_on_Happy_Path_output.json
+++ b/src/itest/resources/payload/output/satisfied_on_Happy_Path_output.json
@@ -62,7 +62,6 @@
         "insolvency_cases" : [ 
             {
                 "case_number" : null,
-                "transaction_id" : null,
                 "links" : null
             }
         ],

--- a/src/main/resources/specifications/private.api.ch.gov.uk-specifications/charges/charges.json
+++ b/src/main/resources/specifications/private.api.ch.gov.uk-specifications/charges/charges.json
@@ -411,13 +411,8 @@
       "title": "InsolvencyCasesApi",
       "properties": {
         "case_number": {
-          "type": "integer",
+          "type": "string",
           "description": "The number of this insolvency case"
-        },
-        "transaction_id": {
-          "type": "integer",
-          "format": "int64",
-          "description": "The id of the insolvency filing"
         },
         "links": {
           "description": "The resources related to this insolvency case",

--- a/src/test/resources/charges-api-request-data.json
+++ b/src/test/resources/charges-api-request-data.json
@@ -28,8 +28,7 @@
     "charge_code": "NI6224000001",
     "insolvency_cases": [
       {
-        "case_number": 2,
-        "transaction_id": 22222,
+        "case_number": "2",
         "links": null
       }
     ],


### PR DESCRIPTION
DSND-1086 Removing transaction_id field from InsolvencyCaseApi and changing case_number type from integer to string. Integration and Unit test corrections