### PR TITLE
DSND-1280 Revert log message to not expose Kafka url

### DIFF
--- a/src/main/java/uk/gov/companieshouse/charges/data/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/api/ApiClientService.java
@@ -10,6 +10,4 @@ import uk.gov.companieshouse.api.InternalApiClient;
 public interface ApiClientService {
 
     InternalApiClient getInternalApiClient();
-
-    String getInternalApiUrl();
 }

--- a/src/main/java/uk/gov/companieshouse/charges/data/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/api/ApiClientServiceImpl.java
@@ -24,11 +24,6 @@ public class ApiClientServiceImpl implements ApiClientService {
         return internalApiClient;
     }
 
-    @Override
-    public String getInternalApiUrl() {
-        return internalApiUrl;
-    }
-
     private HttpClient getHttpClient() {
         ApiKeyHttpClient httpClient = new ApiKeyHttpClient(apiKey);
         return httpClient;

--- a/src/main/java/uk/gov/companieshouse/charges/data/api/CompanyMetricsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/api/CompanyMetricsApiService.java
@@ -44,8 +44,6 @@ public class CompanyMetricsApiService {
         logger.info(String.format("Started : getCompanyMetrics for Company Number %s ",
                 companyNumber
         ));
-        logger.info(String.format("CompanyMetricsApiService API URL: [%s]",
-                apiClientService.getInternalApiUrl()));
         final InternalApiClient internalApiClient = this.apiClientService.getInternalApiClient();
         PrivateCompanyMetricsGet companyMetrics =
                 internalApiClient.privateCompanyMetricsResourceHandler()
@@ -64,7 +62,7 @@ public class CompanyMetricsApiService {
                                 + "Status Code: 404 - NOT FOUND for %s.", companyNumber));
             } else {
                 logger.error(String.format("Error calling getCompanyMetrics endpoint. "
-                        + "Status code [%s] + message [%s]", exp.getStatusCode(),
+                        + "Status Code: [%s] - message [%s]", exp.getStatusCode(),
                         exp.getStatusMessage()));
                 throw new ResponseStatusException(exp.getStatusCode(),
                     exp.getStatusMessage(), null);


### PR DESCRIPTION
- Remove getter method from interface and implementation
- Remove logging message to not potentially expose Kafka URL on live.

Resolves [DSND-1280 Release charges delta consumer](https://companieshouse.atlassian.net/browse/DSND-1280)