### PR TITLE
BI-13960: Add rounding of published_at to seconds.

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/charges/data/config/AbstractMongoConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/charges/data/config/AbstractMongoConfig.java
@@ -1,14 +1,9 @@
 package uk.gov.companieshouse.charges.data.config;
 
-import java.time.Duration;
-
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
 
 /**
  * Mongodb configuration.

--- a/src/main/java/uk/gov/companieshouse/charges/data/api/ChargesApiService.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/api/ChargesApiService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.charges.data.api;
 
-import java.time.OffsetDateTime;
-
+import java.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -14,6 +13,7 @@ import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.charges.data.util.DateTimeFormatter;
 import uk.gov.companieshouse.logging.Logger;
 
 @Service
@@ -64,7 +64,7 @@ public class ChargesApiService {
                                                String chargeId, ChargeApi chargeApi) {
         ChangedResourceEvent event = new ChangedResourceEvent();
         event.setType(CHANGED_EVENT_TYPE);
-        event.setPublishedAt(String.valueOf(OffsetDateTime.now()));
+        event.setPublishedAt(DateTimeFormatter.formatPublishedAt(Instant.now()));
         ChangedResource changedResource = new ChangedResource();
         if (chargeApi != null) {
             changedResource.setDeletedData(chargeApi);

--- a/src/main/java/uk/gov/companieshouse/charges/data/repository/ChargesRepository.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/repository/ChargesRepository.java
@@ -2,12 +2,10 @@ package uk.gov.companieshouse.charges.data.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
-import uk.gov.companieshouse.api.charges.ChargeApi;
 import uk.gov.companieshouse.charges.data.model.ChargesAggregate;
 import uk.gov.companieshouse.charges.data.model.ChargesDocument;
 

--- a/src/main/java/uk/gov/companieshouse/charges/data/util/DateTimeFormatter.java
+++ b/src/main/java/uk/gov/companieshouse/charges/data/util/DateTimeFormatter.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.charges.data.util;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -9,11 +11,14 @@ public class DateTimeFormatter {
     static final String strPattern = "\\d{4}-\\d{2}-\\d{2}";
     static final Pattern pattern = Pattern.compile(strPattern);
 
-    static java.time.format.DateTimeFormatter WriteDateTimeFormatter =
+    static java.time.format.DateTimeFormatter writeDateTimeFormatter =
             java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     static java.time.format.DateTimeFormatter readDateTimeFormatter =
             java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    static java.time.format.DateTimeFormatter publishedAtDateTimeFormatter =
+            java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     /**
      * Parse date string to LocalDate.
@@ -32,7 +37,15 @@ public class DateTimeFormatter {
      * @return formatted date as string.
      */
     public static String format(LocalDate localDate) {
-        return localDate.atStartOfDay().format(WriteDateTimeFormatter);
+        return localDate.atStartOfDay().format(writeDateTimeFormatter);
     }
 
+    /**
+     * Format publishedAt date
+     * @param now current time as Instant
+     * @return UTC time as string rounded to seconds
+     */
+    public static String formatPublishedAt(Instant now) {
+        return publishedAtDateTimeFormatter.format(now.atZone(ZoneOffset.UTC));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/charges/data/util/DateTimeFormatterTest.java
+++ b/src/test/java/uk/gov/companieshouse/charges/data/util/DateTimeFormatterTest.java
@@ -1,29 +1,44 @@
 package uk.gov.companieshouse.charges.data.util;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
-public class DateTimeFormatterTest {
+class DateTimeFormatterTest {
 
     @Test
-    public void shouldParseAndFormatGivenDateString() {
+    void shouldParseAndFormatGivenDateString() {
         LocalDate parsedValue = DateTimeFormatter.parse("2015-06-26T08:31:35.058Z");
         assertThat(parsedValue).isNotNull();
-        assertThat(parsedValue.toString()).isEqualTo("2015-06-26");
+        assertThat(parsedValue).hasToString("2015-06-26");
     }
 
     @Test
-    public void throwExceptionWhenGivenWrongDate() {
+    void throwExceptionWhenGivenWrongDate() {
         assertThrows(IllegalStateException.class, () -> DateTimeFormatter.parse("2015 08:31:35.058Z"));
     }
 
     @Test
-    public void shouldFormatGivenDateString() {
+    void shouldFormatGivenDateString() {
         String formattedDate = DateTimeFormatter.format(LocalDate.of(2015, 06, 26));
         assertThat(formattedDate).isNotNull();
         assertThat(formattedDate).isEqualTo("2015-06-26T00:00:00Z");
+    }
+
+    @Test
+    void shouldFormatPublishedAtToCorrectPattern() {
+        // given
+        Instant now = Instant.parse("2024-09-04T10:52:22.235486Z");
+        final String expected = "2024-09-04T10:52:22";
+
+        // when
+        final String actual = DateTimeFormatter.formatPublishedAt(now);
+
+        // then
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
* published_at pattern used in DateTimeFormatter
* Extra test made for DateTimeFormatterTest
* some simple Sonar issues cleaned up

[BI-13960](https://companieshouse.atlassian.net/browse/BI-13960)

[BI-13960]: https://companieshouse.atlassian.net/browse/BI-13960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ